### PR TITLE
Change to a single carousel button

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -111,7 +111,7 @@ const App = () => {
 
     {/* Linking specific routes to specific paths */}
     <div className="navigationLinksHome">
-    <Link to="/home">Homepage</Link>
+    <Link to="/">Homepage</Link>
     </div>
     <div className="navigationLinksAccount">
     <Link to="/account">Account</Link>
@@ -129,7 +129,7 @@ const App = () => {
 
     {/* Specifying the paths and associating them with various files to display different pages */}
     <Routes>
-      <Route path="/home" element={<HomePage movieData={movieData} apiFetch={apiFetch} searchTerm={searchTerm} setSearchTerm={setSearchTerm} />} />
+      <Route path="/" element={<HomePage movieData={movieData} apiFetch={apiFetch} searchTerm={searchTerm} setSearchTerm={setSearchTerm} />} />
       <Route path="/account" element={<Account></Account>}></Route>
     </Routes>
 

--- a/src/pages/home.css
+++ b/src/pages/home.css
@@ -26,10 +26,10 @@ img {
 }
 
 #buttonarrow {
-
+    position: absolute;
+    bottom: 27%;
+    left: 40%;
     display: flex;
-    justify-content: center;
-    align-items: center;
     object-fit: cover;
     }
 

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -49,6 +49,7 @@ const HomePage = (props) => {
         </div>
       
       <div className="carousel-container">
+
         {props.movieData?.length > 0
           ? (
               props.movieData.map((movie) => (
@@ -58,11 +59,7 @@ const HomePage = (props) => {
                     <h5>{movie.originalTitleText.text}</h5>
                   </div>
 
-                  <div id="buttonarrow">
-                    <button onClick={carouselScrollLeft}> &#8592; </button>
-                   
-                    <button onClick={carouselScrollRight}> &#8594; </button>
-                  </div>
+
                 </div>
 
               ))
@@ -72,6 +69,11 @@ const HomePage = (props) => {
           
 
         }
+      <div id="buttonarrow">
+          <button onClick={carouselScrollLeft}> &#8592; </button>
+                   
+          <button onClick={carouselScrollRight}> &#8594; </button>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
- Changes the route for the homepage from "/home" to "/", so that the page loads onto the homepage rather than requiring to press the homepage button before loading the homepage.

- Changes the carousel scroll to a single pair of scroll buttons instead of a pair of buttons on every return from the map.